### PR TITLE
Check trace id and span length

### DIFF
--- a/docs/reference/span-id.md
+++ b/docs/reference/span-id.md
@@ -4,4 +4,4 @@ The optional `-sid` or equivalent long form version: `--span-id` exists to provi
 
 ### Valid OTEL Trace ID Length
 
-A valid OpenTelemetry Trace ID is 32 hexidecimal characters long.
+A valid OpenTelemetry Span ID is 16 hexidecimal characters long.

--- a/logpusher.py
+++ b/logpusher.py
@@ -130,6 +130,12 @@ if time_shift_duration != "":
 # This is required by spec
 timestamp = str(timestamp)
 
+if len(trace_id) != 32:
+  print(f"Warning: Trace ID is too short ({len(trace_id)} characters). Collector will fail to accept it.")
+
+if len(span_id) != 16:
+  print(f"Warning: Span ID is too short ({len(span_id)} characters). Collector will fail to accept it.")
+
 log = {
 	"resourceLogs": [{
 		"resource": {

--- a/logpusher.py
+++ b/logpusher.py
@@ -132,9 +132,13 @@ timestamp = str(timestamp)
 
 if len(trace_id) != 32:
   print(f"Warning: Trace ID is too short ({len(trace_id)} characters). Collector will fail to accept it.")
+else:
+  print("Trace ID is of the correct length (32 characters). Collector will accept it.")
 
 if len(span_id) != 16:
   print(f"Warning: Span ID is too short ({len(span_id)} characters). Collector will fail to accept it.")
+else:
+  print("Span ID is of the correct length (16 characters). Collector will accept it.")
 
 log = {
 	"resourceLogs": [{


### PR DESCRIPTION
This PR is designed to add a warning to user if the given trace_id and span_id lengths are not in the OTLP format.